### PR TITLE
Feat/arabic support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Cross platform JavaScript library that implements the thermal printer ESC / POS 
 - [x] Image (base64) (png only)
 - [x] XML with mustache
 
-
 ## Tested manually on following environments or platforms
 
 - [x] React Native (Android)
@@ -31,22 +30,20 @@ Cross platform JavaScript library that implements the thermal printer ESC / POS 
 - [x] Desktop applications (nwjs &amp; electron)
 - [x] Other node environment (terminal)
 
-
 ## Installation
 
 ```bash
-  yarn add @tillpos/xml-escpos-helper
+  yarn add @dailykit/xml-escpos-helper
 ```
 
 ## Examples
 
-### With an XML template +  plain object input (regular text).
+### With an XML template + plain object input (regular text).
 
 ```ts
+import { EscPos } from '@dailykit/xml-escpos-helper';
 
-import { EscPos } from '@tillpos/xml-escpos-helper';
-
-// store this template somewhere `s3` or as `static asset` based on your preference 
+// store this template somewhere `s3` or as `static asset` based on your preference
 const template = `
   <?xml version="1.0" encoding="UTF-8"?>
   <document>
@@ -58,7 +55,7 @@ const template = `
 
     {{#thankyouNote}}
     <align mode="center">
-      <text-line size="0:0">  {{{thankyouNote}}}</text-line>
+      <text-line encoding="cp864" size="0:0">  {{{thankyouNote}}}</text-line>
     </align>
 
     <line-feed />
@@ -67,38 +64,39 @@ const template = `
   </document>
 `;
 
+// if encoding in text-line is not mentioned (by default it is set to utf8)
+
 const input = {
   title: 'Sample',
-  thankyouNote: 'Welcome...!'
+  thankyouNote: 'أهلا بك',
 };
 
 const buffer = EscPos.getBufferFromTemplate(template, input);
 // send this buffer to a stream (eg.: bluetooth or wifi)
-
 ```
 
-### With an XML template +  png image (base64)
+### With an XML template + png image (base64)
 
 ```ts
-  const template =  `<?xml version="1.0" encoding="UTF-8"?>
+const template = `<?xml version="1.0" encoding="UTF-8"?>
   <document>
     <align mode="center">
       <bold>
         <text-line size="1:0">{{title}}</text-line>
       </bold>
-        
+
       <image density="d24">
         {{base64PngImage}}
       </image>
-    </align>    
+    </align>
   </document>`;
 
-  const input = {
-    title: 'PNG - base64',
-    base64PngImage: `data:image/png;base64,iVBORw0KGgoAAA+P/AaNn2GPEMgEFAAAAAElFTkSuQmCC`
-  };
+const input = {
+  title: 'PNG - base64',
+  base64PngImage: `data:image/png;base64,iVBORw0KGgoAAA+P/AaNn2GPEMgEFAAAAAElFTkSuQmCC`,
+};
 
-  const buffer = EscPos.getBufferFromTemplate(template, input);
+const buffer = EscPos.getBufferFromTemplate(template, input);
 ```
 
 ---
@@ -116,21 +114,19 @@ const buffer = EscPos.getBufferFromTemplate(template, input);
 
 - If there is any delay you observe while printing with this library it is mostly due to image manipulations (try without image :mask: )
 
-
 ## Useful links / resources
 
-- [ESC / POS Commands manual](./resources/ESCPOS_Command_Manual.pdf) 
-- A [blog post](https://www.visuality.pl/posts/thermal-printer-protocols-for-image-and-text#:~:text=How%20can%20we%20print%20an,command%20language%20of%20thermal%20printers) explaiing about printing images with ESCPOS 
+- [ESC / POS Commands manual](./resources/ESCPOS_Command_Manual.pdf)
+- A [blog post](https://www.visuality.pl/posts/thermal-printer-protocols-for-image-and-text#:~:text=How%20can%20we%20print%20an,command%20language%20of%20thermal%20printers) explaiing about printing images with ESCPOS
 - Similar library for serverside - [node-escpos](https://github.com/song940/node-escpos).
 
 > Limitations on the react-native framework
 
 - [FileReader.readAsArrayBuffer](https://github.com/facebook/react-native/issues/21209) was not implemented.
-- Most of popular image manupulation libraries does not have support for react-native. eg : [jimp](https://www.npmjs.com/package/jimp), [jpeg-js](https://www.npmjs.com/package/jpeg-js) and [sharp](https://www.npmjs.com/package/sharp). We can use these libraries with some native node lib implemented in react native (some sort of polyfill).  
-- For png this [library](https://github.com/photopea/UPNG.js) seems to be faster, but when tested this library with it, it is not retaining pixels at some places) 
+- Most of popular image manupulation libraries does not have support for react-native. eg : [jimp](https://www.npmjs.com/package/jimp), [jpeg-js](https://www.npmjs.com/package/jpeg-js) and [sharp](https://www.npmjs.com/package/sharp). We can use these libraries with some native node lib implemented in react native (some sort of polyfill).
+- For png this [library](https://github.com/photopea/UPNG.js) seems to be faster, but when tested this library with it, it is not retaining pixels at some places)
 - Use this [node-libs-react-native](https://www.npmjs.com/package/node-libs-react-native) if we need to use this library in react native (adds some mock or js implementation for fs, stream etc)
 
 ---
 
 Contributions of any kind welcome! :heart:
-

--- a/examples/src/templates.ts
+++ b/examples/src/templates.ts
@@ -64,4 +64,4 @@ export const TEMPLATES = {
     <text-line>{{tableData}}</text-line>
     <paper-cut/>
   </document>`,
-}
+};

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@tillpos/xml-escpos-helper",
+  "name": "@dailykit/xml-escpos-helper",
   "description": "ESC/POS with XML interface",
   "keywords": [
     "escpos",
@@ -8,7 +8,7 @@
     "xml",
     "printer"
   ],
-  "version": "0.2.2",
+  "version": "1.0.0",
   "files": [
     "lib",
     "LICENSE",
@@ -28,13 +28,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "http://github.com/hitz-group/xml-escpos-helper.git"
+    "url": "https://github.com/dailykit/xml-escpos-helper.git"
   },
   "contributors": [
     "Snehit Velma <snehithvelma@gmail.com>"
   ],
   "bugs": {
-    "url": "https://github.com/hitz-group/xml-escpos-helper/issues"
+    "url": "https://github.com/dailykit/xml-escpos-helper/issues"
   },
   "dependencies": {
     "arabic-persian-reshaper": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
     "url": "https://github.com/hitz-group/xml-escpos-helper/issues"
   },
   "dependencies": {
+    "arabic-persian-reshaper": "^1.0.1",
     "buffer": "^6.0.3",
+    "iconv-lite": "^0.6.3",
     "mustache": "^4.1.0",
     "mutable-buffer": "2.0.3",
     "ndarray": "^1.0.19",

--- a/src/command.ts
+++ b/src/command.ts
@@ -1,50 +1,77 @@
 export class Command {
+  public static ESC: number = 0x1b;
+  public static FF: number = 0x0c;
+  public static FS: number = 0x1c;
+  public static GS: number = 0x1d;
+  public static DC1: number = 0x11;
+  public static DC4: number = 0x14;
+  public static DLE: number = 0x10;
+  public static NL: number = 0x0a;
+  public static SP: number = 0x20;
+  public static US: number = 0x1f;
 
-  public static ESC: number        = 0x1B;
-  public static FF: number         = 0x0C;
-  public static FS: number         = 0x1C;
-  public static GS: number         = 0x1D;
-  public static DC1: number        = 0x11;
-  public static DC4: number        = 0x14;
-  public static DLE: number        = 0x10;
-  public static NL: number         = 0x0A;
-  public static SP: number         = 0x20;
-  public static US: number         = 0x1F;
-
-  public static DLE_EOT            = (n: number): number[] => [Command.DLE, 0x04, n]; // DLEEOTn
+  public static DLE_EOT = (n: number): number[] => [Command.DLE, 0x04, n]; // DLEEOTn
 
   public static ESC_init: number[] = [Command.ESC, 0x40]; //ESC@
-  public static ESC_exclamation    = (n: number): number[] => [Command.ESC, 0x21, n]; // ESC!n
-  public static ESC_minus          = (n: number): number[] => [Command.ESC, 0x2D, n]; // ESC-n
-  public static ESC_rev            = (n: number): number[] => [Command.ESC, 0x7B, n]; // ESC{n
-  public static ESC_a              = (n: number): number[] => [Command.ESC, 0x61, n]; // ESCan
-  public static ESC_d              = (n: number): number[] => [Command.ESC, 0x64, n]; // ESCdn
-  public static ESC_E              = (n: number): number[] => [Command.ESC, 0x45, n]; // ESCEn
-  public static ESC_G              = (n: number): number[] => [Command.ESC, 0x47, n]; // ESCGn
-  public static ESC_J              = (n: number): number[] => [Command.ESC, 0x4A, n]; // ESCJn
-  public static ESC_M              = (n: number): number[] => [Command.ESC, 0x4D, n]; // ESCMn
-  public static ESC_t              = (n: number): number[] => [Command.ESC, 0x07, n]; // ESCtn
-  public static ESC_Z              = (m: number, n: number, k: number): number[] => [Command.ESC, 0x5A, m, n, k]; // ESCZmnk
+  public static ESC_exclamation = (n: number): number[] => [
+    Command.ESC,
+    0x21,
+    n,
+  ]; // ESC!n
+  public static ESC_minus = (n: number): number[] => [Command.ESC, 0x2d, n]; // ESC-n
+  public static ESC_rev = (n: number): number[] => [Command.ESC, 0x7b, n]; // ESC{n
+  public static ESC_a = (n: number): number[] => [Command.ESC, 0x61, n]; // ESCan
+  public static ESC_d = (n: number): number[] => [Command.ESC, 0x64, n]; // ESCdn
+  public static ESC_E = (n: number): number[] => [Command.ESC, 0x45, n]; // ESCEn
+  public static ESC_G = (n: number): number[] => [Command.ESC, 0x47, n]; // ESCGn
+  public static ESC_J = (n: number): number[] => [Command.ESC, 0x4a, n]; // ESCJn
+  public static ESC_M = (n: number): number[] => [Command.ESC, 0x4d, n]; // ESCMn
+  public static ESC_t = (n: number): number[] => [Command.ESC, 0x07, n]; // ESCtn
+  public static ESC_l = (): number[] => [Command.ESC, 0x4c]; // ESCl
+  public static ESC_T = (n: number): number[] => [Command.ESC, 0x54, n]; // ESCTn
 
-  public static FS_and: number[]   = [Command.FS, 0x40]; //ESC@
+  public static ESC_Z = (m: number, n: number, k: number): number[] => [
+    Command.ESC,
+    0x5a,
+    m,
+    n,
+    k,
+  ]; // ESCZmnk
 
-  public static GS_exclamation     = (n: number): number[] => [Command.GS, 0x21, n]; // ESC!n
-  public static GS_B               = (n: number): number[] => [Command.GS, 0x42, n]; // GSBn
-  public static GS_f               = (n: number): number[] => [Command.GS, 0x66, n]; // GSfn
-  public static GS_h               = (n: number): number[] => [Command.GS, 0x68, n]; // GShn
-  public static GS_H               = (n: number): number[] => [Command.GS, 0x48, n]; // GSHn
-  public static GS_K               = (m: number, n: number): number[] => [Command.GS, 0x6B, m, n]; // GSKmn
-  public static GS_v0              = (m: number): number[] => [Command.GS, 0x76, 0x30, m]; // GSv0m
-  public static GS_w               = (n: number): number[] => [Command.GS, 0x77, n]; // GSwn
-  public static GS_x               = (n: number): number[] => [Command.GS, 0x78, n]; // GSxn
-  public static GS_v               = (m: number, n: number): number[] => [Command.GS, 0x56, m, n]; // GSv
-  public static ESC_ak             = (n: number): number[] => [Command.ESC, 0x2A, n]; // ESC*n
-  public static ESC_akp             = (m: number, nL: number,nH: number ): number[] => [Command.ESC, 0x2A, m, nL, nH]; // ESC*n
+  public static FS_and: number[] = [Command.FS, 0x40]; //ESC@
 
-  public static LF: number[]       = [Command.NL];
+  public static GS_exclamation = (n: number): number[] => [Command.GS, 0x21, n]; // ESC!n
+  public static GS_B = (n: number): number[] => [Command.GS, 0x42, n]; // GSBn
+  public static GS_f = (n: number): number[] => [Command.GS, 0x66, n]; // GSfn
+  public static GS_h = (n: number): number[] => [Command.GS, 0x68, n]; // GShn
+  public static GS_H = (n: number): number[] => [Command.GS, 0x48, n]; // GSHn
+  public static GS_K = (m: number, n: number): number[] => [
+    Command.GS,
+    0x6b,
+    m,
+    n,
+  ]; // GSKmn
+  public static GS_v0 = (m: number): number[] => [Command.GS, 0x76, 0x30, m]; // GSv0m
+  public static GS_w = (n: number): number[] => [Command.GS, 0x77, n]; // GSwn
+  public static GS_x = (n: number): number[] => [Command.GS, 0x78, n]; // GSxn
+  public static GS_v = (m: number, n: number): number[] => [
+    Command.GS,
+    0x56,
+    m,
+    n,
+  ]; // GSv
+  public static ESC_ak = (n: number): number[] => [Command.ESC, 0x2a, n]; // ESC*n
+  public static ESC_akp = (m: number, nL: number, nH: number): number[] => [
+    Command.ESC,
+    0x2a,
+    m,
+    nL,
+    nH,
+  ]; // ESC*n
 
+  public static LF: number[] = [Command.NL];
 
   // Cash Drawer
-  public static CD_KICK_1          = (): number[] => [Command.ESC, 0x70, 0x00];  // Sends a pulse to pin 2
-  public static CD_KICK_2          = (): number[] => [Command.ESC, 0x70, 0x01];  // Sends a pulse to pin 5
+  public static CD_KICK_1 = (): number[] => [Command.ESC, 0x70, 0x00]; // Sends a pulse to pin 2
+  public static CD_KICK_2 = (): number[] => [Command.ESC, 0x70, 0x01]; // Sends a pulse to pin 5
 }

--- a/src/nodes/text-node.ts
+++ b/src/nodes/text-node.ts
@@ -2,20 +2,24 @@ import { XMLNode } from '../xml-node';
 import { BufferBuilder } from '../buffer-builder';
 
 export default class TextNode extends XMLNode {
-
   constructor(node: any) {
     super(node);
   }
 
   public open(bufferBuilder: BufferBuilder): BufferBuilder {
-
+    let encoding: string = this.attributes.encoding || 'utf-8';
+    let processText: string = this.attributes.processText || 'true';
+    console.log('text-node1 processText', processText);
+    console.log('text-node1 encoding', encoding);
     if (/\d+:\d+/.test(this.attributes.size)) {
-      let size: number[] = new String(this.attributes.size).split(':').map(entry => parseInt(entry));
+      let size: number[] = new String(this.attributes.size)
+        .split(':')
+        .map(entry => parseInt(entry));
       bufferBuilder.setCharacterSize(size[0], size[1]);
     }
 
     let text = this.getContent().replace(/&nbsp;/g, ' ');
-    bufferBuilder.printText(text);
+    bufferBuilder.printText(text, encoding, processText);
     return bufferBuilder;
   }
 
@@ -23,5 +27,4 @@ export default class TextNode extends XMLNode {
     bufferBuilder.resetCharacterSize();
     return bufferBuilder;
   }
-
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,223 @@
+export class Util {
+  public static convertArabicForm(text: string): string {
+    const form = {
+      ا: {
+        isolated: 'ﺍ',
+        end: 'ﺎ',
+        middle: '',
+        beginning: '',
+      },
+      ب: {
+        isolated: 'ﺏ',
+        end: 'ﺐ',
+        middle: 'ﺒ',
+        beginning: 'ﺑ',
+      },
+      ت: {
+        isolated: 'ﺕ',
+        end: 'ﺖ',
+        middle: 'ﺘ',
+        beginning: 'ﺗ',
+      },
+      ث: {
+        isolated: 'ﺙ',
+        end: 'ﺚ',
+        middle: 'ﺜ',
+        beginning: 'ﺛ',
+      },
+      ج: {
+        isolated: 'ﺝ',
+        end: 'ﺞ',
+        middle: 'ﺠ',
+        beginning: 'ﺟ',
+      },
+      ح: {
+        isolated: 'ﺡ',
+        end: 'ﺢ',
+        middle: 'ﺤ',
+        beginning: 'ﺣ',
+      },
+      خ: {
+        isolated: 'ﺥ',
+        end: 'ﺦ',
+        middle: 'ﺨ',
+        beginning: 'ﺧ',
+      },
+      د: {
+        isolated: 'ﺩ',
+        end: 'ﺪ',
+        middle: '',
+        beginning: '',
+      },
+      ذ: {
+        isolated: 'ﺫ',
+        end: 'ﺬ',
+        middle: '',
+        beginning: '',
+      },
+      ر: {
+        isolated: 'ﺭ',
+        end: 'ﺮ',
+        middle: '',
+        beginning: '',
+      },
+      ز: {
+        isolated: 'ﺯ',
+        end: 'ﺰ',
+        middle: '',
+        beginning: '',
+      },
+      س: {
+        isolated: 'ﺱ',
+        end: 'ﺲ',
+        middle: 'ﺴ',
+        beginning: 'ﺳ',
+      },
+      ش: {
+        isolated: 'ﺵ',
+        end: 'ﺶ',
+        middle: 'ﺸ',
+        beginning: 'ﺷ',
+      },
+      ص: {
+        isolated: 'ﺹ',
+        end: 'ﺺ',
+        middle: 'ﺼ',
+        beginning: 'ﺻ',
+      },
+      ض: {
+        isolated: 'ﺽ',
+        end: 'ﺾ',
+        middle: 'ﻀ',
+        beginning: 'ﺿ',
+      },
+      ط: {
+        isolated: 'ﻁ',
+        end: 'ﻂ',
+        middle: 'ﻄ',
+        beginning: 'ﻃ',
+      },
+      ظ: {
+        isolated: 'ﻅ',
+        end: 'ﻆ',
+        middle: 'ﻈ',
+        beginning: 'ﻇ',
+      },
+      ع: {
+        isAvailable: true,
+        isolated: 'ﻉ',
+        end: 'ﻊ',
+        middle: 'ﻌ',
+        beginning: 'ﻋ',
+      },
+      غ: {
+        isAvailable: true,
+        isolated: 'ﻍ',
+        end: 'ﻎ',
+        middle: 'ﻐ',
+        beginning: 'ﻏ',
+      },
+      ف: {
+        isolated: 'ﻑ',
+        end: 'ﻒ',
+        middle: 'ﻔ',
+        beginning: 'ﻓ',
+      },
+      ق: {
+        isolated: 'ﻕ',
+        end: 'ﻖ',
+        middle: 'ﻘ',
+        beginning: 'ﻗ',
+      },
+      ك: {
+        isolated: 'ﻙ',
+        end: 'ﻚ',
+        middle: 'ﻜ',
+        beginning: 'ﻛ',
+      },
+      ل: {
+        isolated: 'ﻝ',
+        end: 'ﻞ',
+        middle: 'ﻠ',
+        beginning: 'ﻟ',
+      },
+      م: {
+        isolated: 'ﻡ',
+        end: 'ﻢ',
+        middle: 'ﻤ',
+        beginning: 'ﻣ',
+      },
+      ن: {
+        isolated: 'ﻥ',
+        end: 'ﻦ',
+        middle: 'ﻨ',
+        beginning: 'ﻧ',
+      },
+      ه: {
+        isAvailable: true,
+        isolated: 'ﻩ',
+        end: 'ﻪ',
+        middle: 'ﻬ',
+        beginning: 'ﻫ',
+      },
+      و: {
+        isolated: 'ﻭ',
+        end: 'ﻮ',
+        middle: '',
+        beginning: '',
+      },
+      ي: {
+        isolated: 'ﻱ',
+        end: 'ﻲ',
+        middle: 'ﻴ',
+        beginning: 'ﻳ',
+      },
+      آ: {
+        isolated: 'ﺁ',
+        end: 'ﺂ',
+        middle: '',
+        beginning: '',
+      },
+      ة: {
+        isolated: 'ﺓ',
+        end: 'ﺔ',
+        middle: '',
+        beginning: '',
+      },
+      ى: {
+        isolated: 'ﻯ',
+        end: 'ﻰ',
+        middle: '',
+        beginning: '',
+      },
+    };
+
+    let arabicForm = {
+      end: {},
+      middle: {},
+      beginning: {},
+      isolated: {},
+    };
+    Object.entries(form).forEach(([key, value]) => {
+      if (!value.hasOwnProperty('isAvailable') || !value.isAvailable) {
+        arabicForm['end'][value.end] = value;
+        arabicForm['middle'][value.middle] = value;
+      }
+    });
+
+    // console.log(arabicForm);
+
+    for (let i = 0; i < text.length; i++) {
+      if (arabicForm.end[text[i]]) {
+        // console.log(text[i]);
+        // console.log('inside else if end');
+        text = text.replace(text[i], arabicForm.end[text[i]].isolated);
+      } else if (arabicForm.middle[text[i]]) {
+        // console.log(text[i]);
+        // console.log('inside elseif middle');
+        text = text.replace(text[i], arabicForm.middle[text[i]].beginning);
+      }
+    }
+    return text;
+  }
+}


### PR DESCRIPTION
## Description
This PR added a enconding support on the text-line level, and support for arabic printing.

Issue: 
- Since The text-line node is bydefault encoded in ASCII (in buffer-builder class), hence the international laguages aren't printing properly.
- In original repo Codepage is set to the default i.e. (cp437 Std. Europe), hence that needed to be set dynamically.
- Also if someone needed to print Bilingual receipt, then the codepage is needed to set on each text-line.
- Also for international language (like arabic) we need to encode the text into their respective encoding (like cp864/win1256 for arabic), but their were no support of encoding in the original repo.
- Also even after encoding text into their respective encoding, encoder (like iconv-lite) is not able to detect the character properly, since in the arabic Presentational form B- each character has their 4 different form : Isolated, End, Middle, Beginning, but in iconv-lite End & Middle form of the few characters are missing, hence we have to add our logic to match those form of character as well.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
